### PR TITLE
Exit webdriver

### DIFF
--- a/common/session.py
+++ b/common/session.py
@@ -64,5 +64,7 @@ class session(properties):
         self.logger.addHandler(ch)
 
     def close_web_driver(self):
+        # close browser window
+        self.web_driver.close()
         # close browser windows & exit webdriver
         self.web_driver.quit()

--- a/common/session.py
+++ b/common/session.py
@@ -64,4 +64,5 @@ class session(properties):
         self.logger.addHandler(ch)
 
     def close_web_driver(self):
-        self.web_driver.close()
+        # close browser windows & exit webdriver
+        self.web_driver.quit()


### PR DESCRIPTION
Jenkins job was not ending because chromedriver process did not stop unless ```self.web_driver.quit()``` was call.
http://stackoverflow.com/questions/21320837/release-selenium-chromedriver-exe-from-memory