### PR TITLE
Use env var for properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,18 @@ driver = webdriver.Chrome("/path/to/.cf-ui/")
 ## Configuration
 All configuration on which automation is relied upon should be stored in conf/properties.properties
 
-```
+Properties in conf/properties.properties are overwritten by env variables with same name as in conf/properties.properties or with prefix ```CFUI_```
+So we can use framework testcases to prepare MIQ/CFME+HS for manual testcase if needed without changing conf/properties.properties file.  
 
+```
+export KEEP_BROWSER_RUNNING=True
+export MIQ_HOSTNAME=<your_MIQ_HOSTNAME>
+export MIQ_PORT=80
+
+export HAWKULAR_HOSTNAME=<your_HAWKULAR_HOSTNAME>
+export HAWKULAR_PORT=80
+
+source .cf-ui/bin/activate
+
+python -m pytest tests/framework/test_fast_navigation.py::test_cfui_provider_details
+```

--- a/common/session.py
+++ b/common/session.py
@@ -122,7 +122,8 @@ class session(properties):
     def close_web_driver(self):
         if "True" in self.RECORD_TESTS:
             self.session_recorder.stop()
-        # close browser window
-        self.web_driver.close()
-        # close browser windows & exit webdriver
-        self.web_driver.quit()
+        if not "True" in self.KEEP_BROWSER_RUNNING:
+            # close browser window
+            self.web_driver.close()
+            # close browser windows & exit webdriver
+            self.web_driver.quit()

--- a/conf/properties.properties
+++ b/conf/properties.properties
@@ -32,3 +32,6 @@ VNC_HOSTNAME = localhost
 # vnc display port
 DISPLAY_PORT = 5
 TERMINAL_HEIGHT = 300
+
+# for manual testing
+KEEP_BROWSER_RUNNING = False

--- a/conf/properties.py
+++ b/conf/properties.py
@@ -29,6 +29,22 @@ class properties(object):
         # TODO: parse *.properties file name & path from command line arguments
         # load properties from same dir as this file is in
         propertyArray = self.read_properties_file(os.path.dirname(__file__) + '/' + self.PROPERTIES_FILE_NAME)
+
+        # overwrite with env variables if possible
+        for (propName, propVal) in propertyArray.items():
+            try:
+                propVal=os.environ[propName]
+                if propVal:
+                    propertyArray[propName]=propVal
+            except KeyError:
+                pass
+            try:
+                propVal=os.environ['CFUI_'+propName]
+                if propVal:
+                    propertyArray[propName]=propVal
+            except KeyError:
+                pass
+
         # check if propertyArray is not empty
         if propertyArray:
             # set this class's attributes from propertyArray


### PR DESCRIPTION
Using env variables so i would not have to change conf/properties.properties every time i have new MIQ/CFME instance.
Optional KEEP_BROWSER_RUNNING if i want to continue working in open browser session. 