### PR TITLE
Pass entire test list to py.test, and not just one at a time

### DIFF
--- a/scripts/automation/runTests.sh
+++ b/scripts/automation/runTests.sh
@@ -9,29 +9,27 @@ export DISPLAY=:${DISPLAY_PORT}
 source .cf-ui/bin/activate
 
 echo "Starting tests..."
-for TEST_FILE in $TEST_FILES ; do
-    echo $TEST_FILE
+echo $TEST_FILES
 
-    # for debug purposes
-    if [ "$RUN_TESTS" = true ] ; then
+# for debug purposes
+if [ "$RUN_TESTS" = true ] ; then
 
-        # all tests should be independent so order of testing does not matter
-        python -m pytest -s $TEST_FILE --junitxml=polarion-output.xml --ignore=tests/framework # | tee -a ${WORKSPACE}/pytest.log
-        if [ $? -eq 0 ]; then
-            echo "Test Success."
-        else
-            echo "Test Failed."
-            EXIT_STATUS=1
-        fi
-
-        # stop recording
-        echo "RECORD_TESTS: $RECORD_TESTS"
-        if [ "$RECORD_TESTS" == "True" ] ; then
-            pkill -SIGINT -f flvrec.py
-        fi
-
+    # all tests should be independent so order of testing does not matter
+    python -m pytest -s $TEST_FILES --junitxml=output.xml --ignore=tests/framework # | tee -a ${WORKSPACE}/pytest.log
+    if [ $? -eq 0 ]; then
+        echo "Test Success."
     else
-        echo "Skipping tests because of build parameter RUN_TESTS=False"
+        echo "Test Failed."
+        EXIT_STATUS=1
     fi
-done
+
+    # stop recording
+    echo "RECORD_TESTS: $RECORD_TESTS"
+    if [ "$RECORD_TESTS" == "True" ] ; then
+        pkill -SIGINT -f flvrec.py
+    fi
+
+else
+    echo "Skipping tests because of build parameter RUN_TESTS=False"
+fi
 exit $EXIT_STATUS


### PR DESCRIPTION
Made change for miiq-ms-cfui-nightly so that the output.xml contains all of the tests run. The way runTests.sh works prior to this PR is that the .xml will contain only the "last" test run.

Not sure if this change impacts other Jenkins jobs. Please comment if that is the case.