### PR TITLE
Added one more skip in processing JUnit XML results. Now it skips text of 'failure' tag.

### DIFF
--- a/tools/processResults.py
+++ b/tools/processResults.py
@@ -31,6 +31,12 @@ for node in system_err:
     parent = node.getparent()
     parent.remove(node)
 
+#Remove failure texts
+failures = root.findall('testcase/failure')
+for node in failures:
+    node.text = ''
+    node.set('type', 'failure')
+
 # Remove Node Attributes
 for e in root.iter():
     # print e.tag, e.attrib


### PR DESCRIPTION
After Polarion update, our exporter jobs fail.
When there is "failure" tag in junit xml file file huge text in failure tag, it fails to export.
Anyway we did not need that 'text' of failure.
Removing that.