### PR TITLE
Remove Skipped testcase node at all, instead of deleting wrong attributes.

### DIFF
--- a/tools/processResults.py
+++ b/tools/processResults.py
@@ -43,11 +43,10 @@ for node in errors:
     node.text = ''
     node.set('type', 'error')
 
-#Remove skipped texts
-errors = root.findall('testcase/skipped')
-for node in errors:
-    node.text = ''
-    node.set('type', 'skipped')
+#Remove skipped testcases
+skips = root.findall('testcase/skipped')
+for node in skips:
+    node.getparent().getparent().remove(node.getparent())
 
 # Remove Node Attributes
 for e in root.iter():


### PR DESCRIPTION
The current workaround of removing skipped attributes started failing during exporting into polarion.
New workaround is to remove skipped testcase from report, as it is not necessary and not supported in polarion.