### PR TITLE
Requirements for Fedora 24,25,26,27 and RHEL

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,9 @@
 
 HOME=`pwd`
 
+# Install virtualenv, libcurl-devel, gcc, wget, unzip, openssl-devel
+yum install python-virtualenv wget unzip libcurl-devel unzip gcc openssl-devel -y
+
 # Setup virtual environment
 virtualenv .cf-ui
 source .cf-ui/bin/activate
@@ -20,9 +23,12 @@ then
     pip install setuptools --upgrade
 fi
 
-pip uninstall --yes pycurl
-export PYCURL_SSL_LIBRARY=nss
-pip install pycurl
+#pip uninstall --yes pycurl
+#export PYCURL_SSL_LIBRARY=nss
+#pip install pycurl
+
+## Requirement for Fedora 27 (https://github.com/siznax/wptools/issues/68)
+pip install --no-cache-dir --compile --ignore-installed --install-option="--with-openssl" pycurl
 
 pip install mgmtsystem==1.6.1
 


### PR DESCRIPTION
# Additions
- `python-virtualenv`
- `pycurl with openssl` (needed because of https://bugzilla.redhat.com/show_bug.cgi?id=1446850, and https://github.com/siznax/wptools/issues/68)
-  `unzip` 
- `wget`
- `unzip`
- `openssl-devel` needed because of https://bugzilla.redhat.com/show_bug.cgi?id=1454462)

## Test Enviroment

- Tested under fedora: `fedora 24,25,26 and 27`
- Tested under RHEL 7.4