### PR TITLE
Including Conditional for Fedora 27 and Including RedHat-RPM-Config Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ```shell
 git clone https://github.com/Hawkular-QE/cf-ui.git
 cd cf-ui
-./setup.sh
+sudo ./setup.sh
 source .cf-ui/bin/activate
 ```
 ## Configuration

--- a/setup.sh
+++ b/setup.sh
@@ -23,12 +23,15 @@ then
     pip install setuptools --upgrade
 fi
 
-#pip uninstall --yes pycurl
-#export PYCURL_SSL_LIBRARY=nss
-#pip install pycurl
+pip uninstall --yes pycurl
+export PYCURL_SSL_LIBRARY=nss
+pip install pycurl
 
 ## Requirement for Fedora 27 (https://github.com/siznax/wptools/issues/68)
+if grep -q -i "fedora 27" /etc/os-release
+then 
 pip install --no-cache-dir --compile --ignore-installed --install-option="--with-openssl" pycurl
+fi
 
 pip install mgmtsystem==1.6.1
 

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 HOME=`pwd`
 
 # Install virtualenv, libcurl-devel, gcc, wget, unzip, openssl-devel
-yum install python-virtualenv wget unzip libcurl-devel unzip gcc openssl-devel -y
+yum install python-virtualenv wget unzip libcurl-devel unzip gcc openssl-devel redhat-rpm-config -y
 
 # Setup virtual environment
 virtualenv .cf-ui


### PR DESCRIPTION
- Including a package for redhat-rpm-config-package which is mandatory for some gcc imports on fedora and including a conditional for fedora 27 setup.

Also, a included a sudo on README in order to make the installing process work on a single command