### PR TITLE
Set testsuite name the name of project in polarion.

### DIFF
--- a/tools/processResults.py
+++ b/tools/processResults.py
@@ -48,6 +48,10 @@ skips = root.findall('testcase/skipped')
 for node in skips:
     node.getparent().getparent().remove(node.getparent())
 
+#Fix the polarion project name
+suite = root.getroot()
+suite.set('name', 'JBossON4')
+
 # Remove Node Attributes
 for e in root.iter():
     # print e.tag, e.attrib


### PR DESCRIPTION
Keeping project name hardcoded for now.
This change is necessary for the newest Polarion exporter plugin we use.

Probably more changes are upcoming because now it creates the Run by default name.