### PR TITLE
Alerts refactoring

### DIFF
--- a/common/model/alert.py
+++ b/common/model/alert.py
@@ -1,0 +1,12 @@
+'''
+Created on December 7th
+
+@author: gbaufake
+
+Model for Alert Information
+'''
+
+
+class Alert:
+    pass
+

--- a/common/model/alert_category.py
+++ b/common/model/alert_category.py
@@ -1,0 +1,42 @@
+from enum import Enum
+
+class AlertCategory(Enum):
+
+    # Datasource Alerts
+    datasource_connection_creation_time = 'DataSource - Connection Creation Time'
+    datasource_connection_get_time = 'DataSource - Connection Get Time'
+    datasource_connection_wait_time = 'DataSource - Connection Wait Time'
+    datasource_connections_available = 'DataSource - Connections Available'
+    datasource_connections_in_use = 'DataSource - Connections In Use'
+    datasource_connections_timeout = 'DataSource - Connections Time Out'
+
+    # EAP Alerts
+    eap_transactions_aborted = 'EAP Transactions - Aborted'
+    eap_transactions_application_rollback = 'EAP Transactions - Application Rollbacks'
+    eap_transactions_committed = 'EAP Transactions - Committed'
+    eap_transactions_heuristic = 'EAP Transactions - Heuristic'
+    eap_transactions_resource_rollback = 'EAP Transactions - Resource Rollbacks'
+    eap_transactions_timed_out = 'EAP Transactions - Timed Out'
+
+
+    # JVM
+    jvm_accumulated_gc_duration = 'JVM Accumulated GC Duration'
+    jvm_heap_used = 'JVM Heap Used'
+    jvm_non_heap_used = 'JVM Non Heap Used'
+
+
+    # Messaging
+    messaging_delivery_message_count = 'Messaging - Delivering Message Count'
+    messaging_durable_message_count = 'Messaging - Durable Message Count'
+    messaging_durable_subscribers = 'Messaging - Durable Subscribers'
+    messaging_messages_added = 'Messaging - Messages Added'
+    messaging_messages_count = 'Messaging - Messages Count'
+    messaging_non_durable_message_count = 'Messaging - Non-durable Message Count'
+    messaging_non_durable_subscribers = 'Messaging - Non-durable Subscribers'
+    messaging_subscriptions = 'Messaging - Subscriptions'
+
+
+    # Web sessions
+    web_sessions_active = 'Web sessions - Active'
+    web_sessions_expired = 'Web sessions - Expired'
+    web_sessions_rejected = 'Web sessions - Rejected'

--- a/common/model/alert_category.py
+++ b/common/model/alert_category.py
@@ -40,3 +40,7 @@ class AlertCategory(Enum):
     web_sessions_active = 'Web sessions - Active'
     web_sessions_expired = 'Web sessions - Expired'
     web_sessions_rejected = 'Web sessions - Rejected'
+
+    @staticmethod
+    def list():
+        return map(lambda c: c.value, AlertCategory)

--- a/common/model/alert_factory.py
+++ b/common/model/alert_factory.py
@@ -1,3 +1,5 @@
+import uuid
+
 from alert import Alert
 from alert_category import AlertCategory
 
@@ -19,10 +21,42 @@ class AlertFactory:
         alert = Alert()
         alert.description = description
         alert.category = alertCategory.value
+        alert.category_key = alertCategory.name
         alert.fields = self.fields_for_ui(alertCategory.name, values)
 
         return alert
 
 
+    def all_alerts(self):
+        alerts = []
+        for category in AlertCategory:
+            alert = Alert()
+
+            if category.name == 'jvm_heap_used' or category.name == 'jvm_non_heap_used':
+                values = [20, 10]
+            else:
+                values = [0]
+                alert.operator = '>='
+
+            alert.category = category.value
+            alert.category_key = category.name
+            alert.description = "Alert-" + str(uuid.uuid4())
+            alert.fields = self.fields_for_ui(category.name, values)
+            alerts.append(alert)
+        return alerts
 
 
+    def jvm_alerts(self):
+        return list(filter(lambda element: element.category_key.startswith("jvm"), self.all_alerts()))
+
+    def web_sessions_alerts(self):
+        return list(filter(lambda element: element.category_key.startswith("web_sessions"), self.all_alerts()))
+
+    def eap_transactions_alerts(self):
+        return list(filter(lambda element: element.category_key.startswith("eap_transactions"), self.all_alerts()))
+
+    def messaging_alerts(self):
+        return list(filter(lambda element: element.category_key.startswith("messaging"), self.all_alerts()))
+
+    def datasource_alerts(self):
+        return list(filter(lambda element: element.category_key.startswith("datasource"), self.all_alerts()))

--- a/common/model/alert_factory.py
+++ b/common/model/alert_factory.py
@@ -1,0 +1,28 @@
+from alert import Alert
+from alert_category import AlertCategory
+
+
+class AlertFactory:
+    def fields_for_ui(self, category, values):
+        key= {
+            'jvm_accumulated_gc_duration': ['value_mw_garbage_collector'],
+            'jvm_heap_used': ['value_mw_greater_than', 'value_mw_less_than'],
+            'jvm_non_heap_used': ['value_mw_greater_than', 'value_mw_less_than']
+        }.get(category, ['value_mw_threshold'])
+
+        return zip(key, values)
+
+
+    # Factory Method
+    def create_alert(self, description, category, values):
+        alertCategory = AlertCategory[category]
+        alert = Alert()
+        alert.description = description
+        alert.category = alertCategory.value
+        alert.fields = self.fields_for_ui(alertCategory.name, values)
+
+        return alert
+
+
+
+

--- a/common/model/alert_factory.py
+++ b/common/model/alert_factory.py
@@ -5,12 +5,19 @@ from alert_category import AlertCategory
 
 
 class AlertFactory:
-    def fields_for_ui(self, category, values):
+
+    def fields_for_ui(self, category):
         key= {
             'jvm_accumulated_gc_duration': ['value_mw_garbage_collector'],
             'jvm_heap_used': ['value_mw_greater_than', 'value_mw_less_than'],
             'jvm_non_heap_used': ['value_mw_greater_than', 'value_mw_less_than']
         }.get(category, ['value_mw_threshold'])
+
+        values = {
+            'jvm_heap_used': [20, 10],
+            'jvm_non_heap_used': [20, 10]
+        }.get(category, [0])
+
 
         return zip(key, values)
 
@@ -32,16 +39,13 @@ class AlertFactory:
         for category in AlertCategory:
             alert = Alert()
 
-            if category.name == 'jvm_heap_used' or category.name == 'jvm_non_heap_used':
-                values = [20, 10]
-            else:
-                values = [0]
+            if not (category.name == 'jvm_heap_used' or category.name == 'jvm_non_heap_used'):
                 alert.operator = '>='
 
             alert.category = category.value
             alert.category_key = category.name
             alert.description = "Alert-" + str(uuid.uuid4())
-            alert.fields = self.fields_for_ui(category.name, values)
+            alert.fields = self.fields_for_ui(category.name)
             alerts.append(alert)
         return alerts
 

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,7 @@ HOME=`pwd`
 # Install virtualenv, libcurl-devel, gcc, wget, unzip, openssl-devel
 yum install python-virtualenv wget unzip libcurl-devel unzip gcc openssl-devel -y
 
+
 # Setup virtual environment
 virtualenv .cf-ui
 source .cf-ui/bin/activate

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,6 +1,6 @@
 import pytest
 from common.session import session
-from views.eap_web_sessions_alerts import eap_web_session_alerts
+from views.alerts import eap_web_session_alerts
 from common.model.alert_factory import AlertFactory
 
 
@@ -46,7 +46,7 @@ def test_add_and_remove_messaging(web_session):
         assert eap_web_session_alerts(web_session, alert).add_alert()
         assert eap_web_session_alerts(web_session, alert).remove_alert()
 
-def test_add_and_remove_messaging(web_session):
+def test_add_and_remove_datasource(web_session):
     alerts = AlertFactory().datasource_alerts()
     for alert in alerts:
         web_session.logger.info("Begin Add/Remove alert {}", alert.category)

--- a/tests/test_eap_jvm_alerts.py
+++ b/tests/test_eap_jvm_alerts.py
@@ -2,6 +2,8 @@ import pytest
 from common.session import session
 from views.eap_jvm_alerts import eap_jvm_alerts
 
+# TODO @gbaufake - to be refactored and included on test_alerts (edit, copy)
+
 @pytest.fixture (scope='session')
 def web_session(request):
     web_session = session(add_provider=True)

--- a/tests/test_eap_jvm_alerts.py
+++ b/tests/test_eap_jvm_alerts.py
@@ -1,6 +1,6 @@
 import pytest
 from common.session import session
-from views.eap_alerts import eap_alerts
+from views.eap_jvm_alerts import eap_jvm_alerts
 
 @pytest.fixture (scope='session')
 def web_session(request):
@@ -18,18 +18,18 @@ def web_session(request):
 
 def test_add_mw_alert(web_session):
     web_session.logger.info("Begin Add alert test")
-    assert eap_alerts(web_session).add_alert()
+    assert eap_jvm_alerts(web_session).add_alert()
 
 def test_copy_mw_alert(web_session):
     web_session.logger.info("Begin Copy alert test")
-    assert eap_alerts(web_session).copy_alert()
+    assert eap_jvm_alerts(web_session).copy_alert()
 
 def test_edit_mw_alert(web_session):
     web_session.logger.info("Begin Edit alert test")
-    assert eap_alerts(web_session).edit_alert()
+    assert eap_jvm_alerts(web_session).edit_alert()
 
 def test_delete_mw_alert(web_session):
     web_session.logger.info("Begin delete alert test")
-    assert eap_alerts(web_session).delete_alert(eap_alerts.editalert_desc)
-    assert eap_alerts(web_session).delete_alert(eap_alerts.copyalert_desc)
+    assert eap_jvm_alerts(web_session).delete_alert(eap_jvm_alerts.editalert_desc)
+    assert eap_jvm_alerts(web_session).delete_alert(eap_jvm_alerts.copyalert_desc)
 

--- a/tests/test_eap_web_sessions_alerts.py
+++ b/tests/test_eap_web_sessions_alerts.py
@@ -31,7 +31,6 @@ def test_add_remove_web_session_alert(web_session):
     assert eap_web_session_alerts(web_session, alert).add_alert()
     assert eap_web_session_alerts(web_session, alert).remove_alert()
 
-
 def test_add_jvm_alert(web_session):
     alert = AlertFactory().create_alert("Alert-" + str(uuid.uuid4()), "jvm_heap_used", ['90', '10'])
     web_session.logger.info("Begin " + alert.category + " Test")

--- a/tests/test_eap_web_sessions_alerts.py
+++ b/tests/test_eap_web_sessions_alerts.py
@@ -1,11 +1,13 @@
 import pytest
 from common.session import session
 from views.eap_web_sessions_alerts import eap_web_session_alerts
+from common.model.alert_factory import AlertFactory
+import uuid
 
 @pytest.fixture (scope='session')
 def web_session(request):
     web_session = session(add_provider=True)
-    web_session.logger.info("Web Session Alerts")
+    web_session.logger.info("Alerts")
 
     def closeSession():
         web_session.logger.info("Close browser session")
@@ -16,8 +18,21 @@ def web_session(request):
     return web_session
 
 
-def test_add_mw_alert(web_session):
-    web_session.logger.info("Begin Add alert test")
-    assert eap_web_session_alerts(web_session).add_alert()
+def test_add_web_session_alert(web_session):
+    alert = AlertFactory().create_alert("Alert-" + str(uuid.uuid4()), "web_sessions_active", ['0'])
+    alert.operator = ">="
+    web_session.logger.info("Begin " + alert.category + " Test")
+    assert eap_web_session_alerts(web_session, alert).add_alert()
+
+def test_add_remove_web_session_alert(web_session):
+    alert = AlertFactory().create_alert("Alert-" + str(uuid.uuid4()), "web_sessions_active", ['0'])
+    alert.operator = ">="
+    web_session.logger.info("Begin " + alert.category + " Test")
+    assert eap_web_session_alerts(web_session, alert).add_alert()
+    assert eap_web_session_alerts(web_session, alert).remove_alert()
 
 
+def test_add_jvm_alert(web_session):
+    alert = AlertFactory().create_alert("Alert-" + str(uuid.uuid4()), "jvm_heap_used", ['90', '10'])
+    web_session.logger.info("Begin " + alert.category + " Test")
+    assert eap_web_session_alerts(web_session, alert).add_alert()

--- a/tests/test_eap_web_sessions_alerts.py
+++ b/tests/test_eap_web_sessions_alerts.py
@@ -1,0 +1,23 @@
+import pytest
+from common.session import session
+from views.eap_web_sessions_alerts import eap_web_session_alerts
+
+@pytest.fixture (scope='session')
+def web_session(request):
+    web_session = session(add_provider=True)
+    web_session.logger.info("Web Session Alerts")
+
+    def closeSession():
+        web_session.logger.info("Close browser session")
+        web_session.close_web_driver()
+
+    request.addfinalizer(closeSession)
+
+    return web_session
+
+
+def test_add_mw_alert(web_session):
+    web_session.logger.info("Begin Add alert test")
+    assert eap_web_session_alerts(web_session).add_alert()
+
+

--- a/tests/test_eap_web_sessions_alerts.py
+++ b/tests/test_eap_web_sessions_alerts.py
@@ -2,7 +2,7 @@ import pytest
 from common.session import session
 from views.eap_web_sessions_alerts import eap_web_session_alerts
 from common.model.alert_factory import AlertFactory
-import uuid
+
 
 @pytest.fixture (scope='session')
 def web_session(request):
@@ -18,20 +18,37 @@ def web_session(request):
     return web_session
 
 
-def test_add_web_session_alert(web_session):
-    alert = AlertFactory().create_alert("Alert-" + str(uuid.uuid4()), "web_sessions_active", ['0'])
-    alert.operator = ">="
-    web_session.logger.info("Begin " + alert.category + " Test")
-    assert eap_web_session_alerts(web_session, alert).add_alert()
+def test_add_and_remove_jvm_alerts(web_session):
+    alerts = AlertFactory().jvm_alerts()
+    for alert in alerts:
+        web_session.logger.info("Begin Add/Remove alert {}", alert.category)
+        assert eap_web_session_alerts(web_session, alert).add_alert()
+        assert eap_web_session_alerts(web_session, alert).remove_alert()
 
-def test_add_remove_web_session_alert(web_session):
-    alert = AlertFactory().create_alert("Alert-" + str(uuid.uuid4()), "web_sessions_active", ['0'])
-    alert.operator = ">="
-    web_session.logger.info("Begin " + alert.category + " Test")
-    assert eap_web_session_alerts(web_session, alert).add_alert()
-    assert eap_web_session_alerts(web_session, alert).remove_alert()
+def test_add_and_remove_web_session_alerts(web_session):
+    alerts = AlertFactory().web_sessions_alerts()
+    for alert in alerts:
+        web_session.logger.info("Begin Add/Remove alert {}", alert.category)
+        assert eap_web_session_alerts(web_session, alert).add_alert()
+        assert eap_web_session_alerts(web_session, alert).remove_alert()
 
-def test_add_jvm_alert(web_session):
-    alert = AlertFactory().create_alert("Alert-" + str(uuid.uuid4()), "jvm_heap_used", ['90', '10'])
-    web_session.logger.info("Begin " + alert.category + " Test")
-    assert eap_web_session_alerts(web_session, alert).add_alert()
+def test_add_and_remove_eap_transactions_alerts(web_session):
+    alerts = AlertFactory().eap_transactions_alerts()
+    for alert in alerts:
+        web_session.logger.info("Begin Add/Remove alert {}", alert.category)
+        assert eap_web_session_alerts(web_session, alert).add_alert()
+        assert eap_web_session_alerts(web_session, alert).remove_alert()
+
+def test_add_and_remove_messaging(web_session):
+    alerts = AlertFactory().messaging_alerts()
+    for alert in alerts:
+        web_session.logger.info("Begin Add/Remove alert {}", alert.category)
+        assert eap_web_session_alerts(web_session, alert).add_alert()
+        assert eap_web_session_alerts(web_session, alert).remove_alert()
+
+def test_add_and_remove_messaging(web_session):
+    alerts = AlertFactory().datasource_alerts()
+    for alert in alerts:
+        web_session.logger.info("Begin Add/Remove alert {}", alert.category)
+        assert eap_web_session_alerts(web_session, alert).add_alert()
+        assert eap_web_session_alerts(web_session, alert).remove_alert()

--- a/views/alerts.py
+++ b/views/alerts.py
@@ -23,8 +23,6 @@ class eap_web_session_alerts:
     def add_alert(self):
         navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
 
-        self.ui_utils.sleep(5)
-
 
         if not self.web_session.web_driver.find_element_by_xpath("//*[@id='alert_accord']").is_displayed():
             self.web_session.web_driver.find_element_by_xpath("//a[contains(text(),'Alerts')]").click()
@@ -32,25 +30,15 @@ class eap_web_session_alerts:
 
         self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li").click()
 
-        self.ui_utils.sleep(2)
-
 
         self.web_session.web_driver.find_element_by_xpath("//button[@title='Configuration']").click()
 
         self.web_session.web_driver.find_element_by_xpath("//a[@title='Add a New Alert']").click()
         assert self.ui_utils.waitForTextOnPage("Adding a new Alert", 90)
 
-        # Show in Timeline
-        self.web_session.web_driver.find_element_by_id("send_evm_event_cb").click()
-        self.ui_utils.sleep(1)
-
         # Select Middleware
-        Select(self.web_session.web_driver.find_element_by_id("miq_alert_db")).select_by_visible_text("Middleware Server")
-        self.ui_utils.sleep(1)
-
-
-        # Severity
-        Select(self.web_session.web_driver.find_element_by_id("miq_alert_severity")).select_by_visible_text("Info")
+        Select(self.web_session.web_driver.find_element_by_id("miq_alert_db")).select_by_visible_text(
+            "Middleware Server")
         self.ui_utils.sleep(1)
 
 
@@ -58,11 +46,18 @@ class eap_web_session_alerts:
         Select(self.web_session.web_driver.find_element_by_id("exp_name")).select_by_visible_text(self.alert.category)
         self.ui_utils.sleep(1)
 
+        # Show in Timeline
+        self.web_session.web_driver.find_element_by_id("send_evm_event_cb").click()
+
+        # Severity
+        Select(self.web_session.web_driver.find_element_by_id("miq_alert_severity")).select_by_visible_text("Info")
+
+
+
         # Sending Tuple
         for field in self.alert.fields:
             self.web_session.web_driver.find_element_by_id(field[0]).send_keys(str(field[1]))
 
-        self.ui_utils.sleep(1)
         # Notification Frequency
         Select(self.web_session.web_driver.find_element_by_id("repeat_time")).select_by_visible_text("1 Minute")
 
@@ -72,10 +67,10 @@ class eap_web_session_alerts:
         else:
             self.web_session.logger.info("Nothing to do here")
 
+        self.ui_utils.sleep(1)
         # Description
         self.web_session.web_driver.find_element_by_xpath("//input[@id='description']").send_keys(
             self.alert.description)
-
 
         self.web_session.web_driver.find_element_by_xpath("//button[contains(.,'Add')]").click()
         assert self.ui_utils.waitForTextOnPage('Alert "{}" was added'.format(self.alert.description), 200)
@@ -88,22 +83,19 @@ class eap_web_session_alerts:
 
         navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
 
-        self.ui_utils.sleep(5)
-
         if not self.web_session.web_driver.find_element_by_xpath("//*[@id='alert_accord']").is_displayed():
             self.web_session.web_driver.find_element_by_xpath("//a[contains(text(),'Alerts')]").click()
 
-        self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li[2]").click()
-
-        self.ui_utils.sleep(2)
-
-        self.web_session.web_driver.find_element_by_xpath("//button[@title='Configuration']").click()
-
-        self.web_session.web_driver.find_element_by_id("miq_alert_vmdb_choice__alert_delete").click()
-        self.ui_utils.accept_alert(20)
-        assert self.ui_utils.waitForTextOnPage('Alert "{}": Delete successful'.format(self.alert.description), 5)
-        self.web_session.logger.info("The alert of category: {} is removed successfully.".format(self.alert.category))
-
-
+        self.ui_utils.get_list_table_as_elements()
+        element = self.ui_utils.get_elements_containing_text(self.alert.description)
+        if element:
+            element[0].click()
+            assert self.ui_utils.waitForTextOnPage('Alert "{}"'.format(self.alert.description), 90)
+            self.web_session.web_driver.find_element_by_xpath("//button[@title='Configuration']").click()
+            self.web_session.web_driver.find_element_by_id("miq_alert_vmdb_choice__alert_delete").click()
+            self.ui_utils.accept_alert(20)
+            assert self.ui_utils.waitForTextOnPage('Alert "{}": Delete successful'.format(self.alert.description), 5)
+            self.web_session.logger.info(
+                "The alert of category: {} is removed successfully.".format(self.alert.category))
 
         return True

--- a/views/eap_jvm_alerts.py
+++ b/views/eap_jvm_alerts.py
@@ -14,7 +14,7 @@ Created on September 22, 2016
 
 '''
 
-class eap_alerts():
+class eap_jvm_alerts():
 
     web_session = None
     alert_desc = "Heap-Alert"

--- a/views/eap_web_sessions_alerts.py
+++ b/views/eap_web_sessions_alerts.py
@@ -18,12 +18,12 @@ class eap_web_session_alerts:
         self.web_session = web_session
         self.web_driver = webdriver
         self.alert = alert
-        self.ui_utils = ui_utils(self.web_session)
+        self.ui_utils = ui_utils(web_session)
 
     def add_alert(self):
         navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
 
-        self.ui_utils(self.web_session).sleep(2)
+        self.ui_utils.sleep(2)
 
         if not self.web_session.web_driver.find_element_by_xpath("//*[@id='alert_accord']").is_displayed():
             self.web_session.web_driver.find_element_by_xpath("//a[contains(text(),'Alerts')]").click()
@@ -31,28 +31,32 @@ class eap_web_session_alerts:
 
         self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li").click()
 
-        self.ui_utils(self.web_session).sleep(2)
+        self.ui_utils.sleep(2)
+
 
         self.web_session.web_driver.find_element_by_xpath("//button[@title='Configuration']").click()
 
         self.web_session.web_driver.find_element_by_xpath("//a[@title='Add a New Alert']").click()
-        assert ui_utils(self.web_session).waitForTextOnPage("Adding a new Alert", 90)
+        assert self.ui_utils.waitForTextOnPage("Adding a new Alert", 90)
 
         # Show in Timeline
         self.web_session.web_driver.find_element_by_id("send_evm_event_cb").click()
-        self.ui_utils(self.web_session).sleep(1)
+        self.ui_utils.sleep(1)
 
         # Select Middleware
         Select(self.web_session.web_driver.find_element_by_id("miq_alert_db")).select_by_visible_text("Middleware Server")
-        self.ui_utils(self.web_session).sleep(1)
+        self.ui_utils.sleep(1)
+
 
         # Severity
         Select(self.web_session.web_driver.find_element_by_id("miq_alert_severity")).select_by_visible_text("Info")
-        self.ui_utils(self.web_session).sleep(1)
+        self.ui_utils.sleep(1)
+
 
         # Category of Alert
         Select(self.web_session.web_driver.find_element_by_id("exp_name")).select_by_visible_text(self.alert.category)
-        self.ui_utils(self.web_session).sleep(1)
+        self.ui_utils.sleep(1)
+
 
         # Description
         self.web_session.web_driver.find_element_by_xpath("//input[@id='description']").send_keys(self.alert.description)
@@ -61,7 +65,7 @@ class eap_web_session_alerts:
         for field in self.alert.fields:
             self.web_session.web_driver.find_element_by_id(field[0]).send_keys(field[1])
 
-        self.ui_utils(self.web_session).sleep(1)
+        self.ui_utils.sleep(1)
         # Notification Frequency
         Select(self.web_session.web_driver.find_element_by_id("repeat_time")).select_by_visible_text("1 Minute")
 
@@ -73,7 +77,7 @@ class eap_web_session_alerts:
 
 
         self.web_session.web_driver.find_element_by_xpath("//button[contains(.,'Add')]").click()
-        assert self.ui_utils(self.web_session).waitForTextOnPage('Alert "{}" was added'.format(self.alert.description), 200)
+        assert self.ui_utils.waitForTextOnPage('Alert "{}" was added'.format(self.alert.description), 200)
 
         return True
 
@@ -82,17 +86,22 @@ class eap_web_session_alerts:
 
         navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
 
-        self.ui_utils(self.web_session).sleep(2)
+        self.ui_utils.sleep(1)
 
         if not self.web_session.web_driver.find_element_by_xpath("//*[@id='alert_accord']").is_displayed():
             self.web_session.web_driver.find_element_by_xpath("//a[contains(text(),'Alerts')]").click()
 
-        self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li").click()
+        self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li[2]").click()
 
-        self.ui_utils(self.web_session).sleep(2)
+        self.ui_utils.sleep(2)
 
         self.web_session.web_driver.find_element_by_xpath("//button[@title='Configuration']").click()
 
         self.web_session.web_driver.find_element_by_id("miq_alert_vmdb_choice__alert_delete").click()
-        self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li[2]").click()
-        self.accept_next_alert = True
+        self.ui_utils.accept_alert(20)
+        assert self.ui_utils.waitForTextOnPage('Alert "{}": Delete successful'.format(self.alert.description), 5)
+        self.web_session.logger.info("The alert {} is removed successfully.".format(self.alert.description))
+
+
+
+        return True

--- a/views/eap_web_sessions_alerts.py
+++ b/views/eap_web_sessions_alerts.py
@@ -1,0 +1,74 @@
+from common.ui_utils import ui_utils
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+from time import sleep
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+from common.navigate import navigate
+
+'''
+
+Created on December 1st
+
+@author: gbaufake
+
+'''
+
+class eap_web_session_alerts:
+    web_session = None
+    alerts_description = "Web Session Alert"
+
+    def __init__(self, web_session):
+        self.web_session = web_session
+        self.web_driver = webdriver
+
+    def add_alert(self):
+
+        navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
+        assert ui_utils(self.web_session).waitForTextOnPage("All Policy Profiles", 15)
+        self.click_alerts()
+        assert ui_utils(self.web_session).waitForTextOnPage("All Alerts", 80)
+
+        assert ui_utils(self.web_session).waitForTextOnPage("Description", 80)
+        #ui_utils(self.web_session).sleep(10)
+        self.web_session.web_driver.find_element_by_xpath("//button[@title='Configuration']").click()
+
+        self.web_session.logger.info("Click done")
+
+        self.web_session.web_driver.find_element_by_xpath("//a[@title='Add a New Alert']").click()
+        assert ui_utils(self.web_session).waitForTextOnPage("Adding a new Alert", 90)
+
+
+        self.web_session.web_driver.find_element_by_xpath("//button[@data-original-title='VM and Instance']").click()
+        self.web_session.web_driver.find_element_by_xpath("//span[contains(.,'Middleware Server')]").click()
+
+        self.web_session.web_driver.find_element_by_xpath("//button[@data-original-title='Nothing']").click()
+        self.web_session.web_driver.find_element_by_xpath("//span[contains(.,'Web Sessions - Active')]").click()
+
+        # Notification Frequency
+        self.web_session.web_driver.find_element_by_xpath("//button[@data-original-title='10 Minutes']").click()
+        self.web_session.web_driver.find_element_by_xpath("//span[contains(.,'1 Minute')]").click()
+
+        ui_utils(self.web_session).sleep(10)
+
+
+
+        # assert ui_utils(self.web_session).waitForTextOnPage("Nothing", 90)
+        # self.web_session.web_driver.find_element_by_xpath("//button[@data-original-title='Nothing']").click()
+        self.web_session.web_driver.find_element_by_xpath("//input[@id='description']").send_keys(self.alerts_description)
+
+        #assert ui_utils(self.web_session).waitForTextOnPage("Web Sessions - Active", 0)
+
+        # self.web_session.web_driver.find_element_by_xpath(".//*[@id='value_mw_greater_than']").send_keys('4')
+        # self.web_session.web_driver.find_element_by_xpath(".//*[@id='value_mw_less_than']").send_keys('2')
+        # self.web_session.web_driver.find_element_by_xpath(".//*[@id='send_evm_event_cb']").click()
+        # ui_utils(self.web_session).sleep(20)
+
+        # self.web_session.web_driver.find_element_by_xpath("//button[contains(.,'Add')]").click()
+        # assert ui_utils(self.web_session).waitForTextOnPage('Alert "{}" was added'.format(self.alert_desc), 90)
+
+        return True
+
+    def click_alerts(self):
+        self.web_session.web_driver.find_element_by_xpath('//*[@id="accordion"]/div[7]/div[1]/h4/a').click()
+        ui_utils(self.web_session).sleep(1)

--- a/views/eap_web_sessions_alerts.py
+++ b/views/eap_web_sessions_alerts.py
@@ -1,9 +1,8 @@
 from common.ui_utils import ui_utils
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support.ui import Select
 from selenium.webdriver.common.by import By
-from time import sleep
 from selenium import webdriver
-from selenium.webdriver.common.keys import Keys
 from common.navigate import navigate
 
 '''
@@ -16,59 +15,85 @@ Created on December 1st
 
 class eap_web_session_alerts:
     web_session = None
-    alerts_description = "Web Session Alert"
 
-    def __init__(self, web_session):
+    def __init__(self, web_session, alert):
         self.web_session = web_session
         self.web_driver = webdriver
+        self.alert = alert
 
     def add_alert(self):
-
         navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
-        assert ui_utils(self.web_session).waitForTextOnPage("All Policy Profiles", 15)
-        self.click_alerts()
-        assert ui_utils(self.web_session).waitForTextOnPage("All Alerts", 80)
 
-        assert ui_utils(self.web_session).waitForTextOnPage("Description", 80)
-        #ui_utils(self.web_session).sleep(10)
+        ui_utils(self.web_session).sleep(2)
+
+        if not self.web_session.web_driver.find_element_by_xpath("//*[@id='alert_accord']").is_displayed():
+            self.web_session.web_driver.find_element_by_xpath("//a[contains(text(),'Alerts')]").click()
+
+
+        self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li").click()
+
+        ui_utils(self.web_session).sleep(2)
+
         self.web_session.web_driver.find_element_by_xpath("//button[@title='Configuration']").click()
-
-        self.web_session.logger.info("Click done")
 
         self.web_session.web_driver.find_element_by_xpath("//a[@title='Add a New Alert']").click()
         assert ui_utils(self.web_session).waitForTextOnPage("Adding a new Alert", 90)
 
+        # Show in Timeline
+        self.web_session.web_driver.find_element_by_id("send_evm_event_cb").click()
+        ui_utils(self.web_session).sleep(1)
 
-        self.web_session.web_driver.find_element_by_xpath("//button[@data-original-title='VM and Instance']").click()
-        self.web_session.web_driver.find_element_by_xpath("//span[contains(.,'Middleware Server')]").click()
+        # Select Middleware
+        Select(self.web_session.web_driver.find_element_by_id("miq_alert_db")).select_by_visible_text("Middleware Server")
+        ui_utils(self.web_session).sleep(1)
 
-        self.web_session.web_driver.find_element_by_xpath("//button[@data-original-title='Nothing']").click()
-        self.web_session.web_driver.find_element_by_xpath("//span[contains(.,'Web Sessions - Active')]").click()
+        # Severity
+        Select(self.web_session.web_driver.find_element_by_id("miq_alert_severity")).select_by_visible_text("Info")
+        ui_utils(self.web_session).sleep(1)
 
+        # Category of Alert
+        Select(self.web_session.web_driver.find_element_by_id("exp_name")).select_by_visible_text(self.alert.category)
+        ui_utils(self.web_session).sleep(1)
+
+        # Description
+        self.web_session.web_driver.find_element_by_xpath("//input[@id='description']").send_keys(self.alert.description)
+
+        # Sending Tuple
+        for field in self.alert.fields:
+            self.web_session.web_driver.find_element_by_id(field[0]).send_keys(field[1])
+
+        ui_utils(self.web_session).sleep(1)
         # Notification Frequency
-        self.web_session.web_driver.find_element_by_xpath("//button[@data-original-title='10 Minutes']").click()
-        self.web_session.web_driver.find_element_by_xpath("//span[contains(.,'1 Minute')]").click()
+        Select(self.web_session.web_driver.find_element_by_id("repeat_time")).select_by_visible_text("1 Minute")
 
-        ui_utils(self.web_session).sleep(10)
+        if hasattr(self.alert, 'operator'):
+            Select(self.web_session.web_driver.find_element_by_id("select_mw_operator")).select_by_visible_text(
+                self.alert.operator)
+        else:
+            self.web_session.logger.info("Nothing to do her")
 
 
-
-        # assert ui_utils(self.web_session).waitForTextOnPage("Nothing", 90)
-        # self.web_session.web_driver.find_element_by_xpath("//button[@data-original-title='Nothing']").click()
-        self.web_session.web_driver.find_element_by_xpath("//input[@id='description']").send_keys(self.alerts_description)
-
-        #assert ui_utils(self.web_session).waitForTextOnPage("Web Sessions - Active", 0)
-
-        # self.web_session.web_driver.find_element_by_xpath(".//*[@id='value_mw_greater_than']").send_keys('4')
-        # self.web_session.web_driver.find_element_by_xpath(".//*[@id='value_mw_less_than']").send_keys('2')
-        # self.web_session.web_driver.find_element_by_xpath(".//*[@id='send_evm_event_cb']").click()
-        # ui_utils(self.web_session).sleep(20)
-
-        # self.web_session.web_driver.find_element_by_xpath("//button[contains(.,'Add')]").click()
-        # assert ui_utils(self.web_session).waitForTextOnPage('Alert "{}" was added'.format(self.alert_desc), 90)
+        self.web_session.web_driver.find_element_by_xpath("//button[contains(.,'Add')]").click()
+        assert ui_utils(self.web_session).waitForTextOnPage('Alert "{}" was added'.format(self.alert.description), 200)
 
         return True
 
-    def click_alerts(self):
-        self.web_session.web_driver.find_element_by_xpath('//*[@id="accordion"]/div[7]/div[1]/h4/a').click()
-        ui_utils(self.web_session).sleep(1)
+
+    def remove_alert(self):
+
+        navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
+
+        ui_utils(self.web_session).sleep(2)
+
+        if not self.web_session.web_driver.find_element_by_xpath("//*[@id='alert_accord']").is_displayed():
+            self.web_session.web_driver.find_element_by_xpath("//a[contains(text(),'Alerts')]").click()
+
+        self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li").click()
+
+        ui_utils(self.web_session).sleep(2)
+
+        self.web_session.web_driver.find_element_by_xpath("//button[@title='Configuration']").click()
+
+        self.web_session.web_driver.find_element_by_id("miq_alert_vmdb_choice__alert_delete").click()
+        self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li[2]").click()
+        self.accept_next_alert = True

--- a/views/eap_web_sessions_alerts.py
+++ b/views/eap_web_sessions_alerts.py
@@ -23,7 +23,8 @@ class eap_web_session_alerts:
     def add_alert(self):
         navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
 
-        self.ui_utils.sleep(2)
+        self.ui_utils.sleep(5)
+
 
         if not self.web_session.web_driver.find_element_by_xpath("//*[@id='alert_accord']").is_displayed():
             self.web_session.web_driver.find_element_by_xpath("//a[contains(text(),'Alerts')]").click()
@@ -57,13 +58,9 @@ class eap_web_session_alerts:
         Select(self.web_session.web_driver.find_element_by_id("exp_name")).select_by_visible_text(self.alert.category)
         self.ui_utils.sleep(1)
 
-
-        # Description
-        self.web_session.web_driver.find_element_by_xpath("//input[@id='description']").send_keys(self.alert.description)
-
         # Sending Tuple
         for field in self.alert.fields:
-            self.web_session.web_driver.find_element_by_id(field[0]).send_keys(field[1])
+            self.web_session.web_driver.find_element_by_id(field[0]).send_keys(str(field[1]))
 
         self.ui_utils.sleep(1)
         # Notification Frequency
@@ -73,11 +70,16 @@ class eap_web_session_alerts:
             Select(self.web_session.web_driver.find_element_by_id("select_mw_operator")).select_by_visible_text(
                 self.alert.operator)
         else:
-            self.web_session.logger.info("Nothing to do her")
+            self.web_session.logger.info("Nothing to do here")
+
+        # Description
+        self.web_session.web_driver.find_element_by_xpath("//input[@id='description']").send_keys(
+            self.alert.description)
 
 
         self.web_session.web_driver.find_element_by_xpath("//button[contains(.,'Add')]").click()
         assert self.ui_utils.waitForTextOnPage('Alert "{}" was added'.format(self.alert.description), 200)
+        self.web_session.logger.info("The alert of category: {} is added successfully.".format(self.alert.category))
 
         return True
 
@@ -86,7 +88,7 @@ class eap_web_session_alerts:
 
         navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
 
-        self.ui_utils.sleep(1)
+        self.ui_utils.sleep(5)
 
         if not self.web_session.web_driver.find_element_by_xpath("//*[@id='alert_accord']").is_displayed():
             self.web_session.web_driver.find_element_by_xpath("//a[contains(text(),'Alerts')]").click()
@@ -100,7 +102,7 @@ class eap_web_session_alerts:
         self.web_session.web_driver.find_element_by_id("miq_alert_vmdb_choice__alert_delete").click()
         self.ui_utils.accept_alert(20)
         assert self.ui_utils.waitForTextOnPage('Alert "{}": Delete successful'.format(self.alert.description), 5)
-        self.web_session.logger.info("The alert {} is removed successfully.".format(self.alert.description))
+        self.web_session.logger.info("The alert of category: {} is removed successfully.".format(self.alert.category))
 
 
 

--- a/views/eap_web_sessions_alerts.py
+++ b/views/eap_web_sessions_alerts.py
@@ -1,7 +1,5 @@
 from common.ui_utils import ui_utils
-from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support.ui import Select
-from selenium.webdriver.common.by import By
 from selenium import webdriver
 from common.navigate import navigate
 
@@ -20,11 +18,12 @@ class eap_web_session_alerts:
         self.web_session = web_session
         self.web_driver = webdriver
         self.alert = alert
+        self.ui_utils = ui_utils(self.web_session)
 
     def add_alert(self):
         navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
 
-        ui_utils(self.web_session).sleep(2)
+        self.ui_utils(self.web_session).sleep(2)
 
         if not self.web_session.web_driver.find_element_by_xpath("//*[@id='alert_accord']").is_displayed():
             self.web_session.web_driver.find_element_by_xpath("//a[contains(text(),'Alerts')]").click()
@@ -32,7 +31,7 @@ class eap_web_session_alerts:
 
         self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li").click()
 
-        ui_utils(self.web_session).sleep(2)
+        self.ui_utils(self.web_session).sleep(2)
 
         self.web_session.web_driver.find_element_by_xpath("//button[@title='Configuration']").click()
 
@@ -41,19 +40,19 @@ class eap_web_session_alerts:
 
         # Show in Timeline
         self.web_session.web_driver.find_element_by_id("send_evm_event_cb").click()
-        ui_utils(self.web_session).sleep(1)
+        self.ui_utils(self.web_session).sleep(1)
 
         # Select Middleware
         Select(self.web_session.web_driver.find_element_by_id("miq_alert_db")).select_by_visible_text("Middleware Server")
-        ui_utils(self.web_session).sleep(1)
+        self.ui_utils(self.web_session).sleep(1)
 
         # Severity
         Select(self.web_session.web_driver.find_element_by_id("miq_alert_severity")).select_by_visible_text("Info")
-        ui_utils(self.web_session).sleep(1)
+        self.ui_utils(self.web_session).sleep(1)
 
         # Category of Alert
         Select(self.web_session.web_driver.find_element_by_id("exp_name")).select_by_visible_text(self.alert.category)
-        ui_utils(self.web_session).sleep(1)
+        self.ui_utils(self.web_session).sleep(1)
 
         # Description
         self.web_session.web_driver.find_element_by_xpath("//input[@id='description']").send_keys(self.alert.description)
@@ -62,7 +61,7 @@ class eap_web_session_alerts:
         for field in self.alert.fields:
             self.web_session.web_driver.find_element_by_id(field[0]).send_keys(field[1])
 
-        ui_utils(self.web_session).sleep(1)
+        self.ui_utils(self.web_session).sleep(1)
         # Notification Frequency
         Select(self.web_session.web_driver.find_element_by_id("repeat_time")).select_by_visible_text("1 Minute")
 
@@ -74,7 +73,7 @@ class eap_web_session_alerts:
 
 
         self.web_session.web_driver.find_element_by_xpath("//button[contains(.,'Add')]").click()
-        assert ui_utils(self.web_session).waitForTextOnPage('Alert "{}" was added'.format(self.alert.description), 200)
+        assert self.ui_utils(self.web_session).waitForTextOnPage('Alert "{}" was added'.format(self.alert.description), 200)
 
         return True
 
@@ -83,14 +82,14 @@ class eap_web_session_alerts:
 
         navigate(self.web_session).get("{}/miq_policy/explorer".format(self.web_session.MIQ_URL))
 
-        ui_utils(self.web_session).sleep(2)
+        self.ui_utils(self.web_session).sleep(2)
 
         if not self.web_session.web_driver.find_element_by_xpath("//*[@id='alert_accord']").is_displayed():
             self.web_session.web_driver.find_element_by_xpath("//a[contains(text(),'Alerts')]").click()
 
         self.web_session.web_driver.find_element_by_xpath("//div[@id='treeview-alert_tree']/ul/li").click()
 
-        ui_utils(self.web_session).sleep(2)
+        self.ui_utils(self.web_session).sleep(2)
 
         self.web_session.web_driver.find_element_by_xpath("//button[@title='Configuration']").click()
 


### PR DESCRIPTION
# New Types of Alerts Tested
  ## Datasource
   - DataSource - Connection Creation Time
   - DataSource - Connection Get Time
   - DataSource - Connection Wait Time
   - DataSource - Connections Available
   - DataSource - Connections In Use
   - DataSource - Connections Time Out

  ## EAP Alerts
   - EAP Transactions - Aborted
   - EAP Transactions - Application Rollbacks
   - EAP Transactions - Committed
   - EAP Transactions - Heuristic
   - EAP Transactions - Resource Rollbacks
   - EAP Transactions - Timed Out


  ### JVM
   - JVM Accumulated GC Duration
   - JVM Heap Used
   - JVM Non Heap Used


  ## Messaging
   - Messaging - Delivering Message Count
   - Messaging - Durable Message Count
   - Messaging - Durable Subscribers
   - Messaging - Messages Added
   - Messaging - Messages Count
   - Messaging - Non-durable Message Count
   - Messaging - Non-durable Subscribers
   - Messaging - Subscriptions


  ### Web sessions
   - Web sessions - Active
   - Web sessions - Expired
   - Web sessions - Rejected

# New Features for Alerts Test
- New Models (Alert, Alert Category) to support Generics

- Factory Class and Factory Method to make alert reusable on other parts of cf-ui code

- Possibility to add specific Operators (When it is the case) (it will help for Datasource and Messaging on Future) (https://github.com/ManageIQ/manageiq-providers-hawkular/pull/103)

# Task List

- [x] Add Generic Alert
- [x] Delete Generic Alert

- [ ] Edit Generic Alert

- [ ] Copy Generic Alert
- [ ] Add Generic Alert to Profile


- [ ] Sync with Timeline Work